### PR TITLE
Update the sample response to use a singular value for the "type" field

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It should also provide some information about the associated tests themselves in
 ```json
 {
   "data": {
-    "type": "test_panels",
+    "type": "test_panel",
     "id": "TP2",
     "attributes": {
       "price": 2100,
@@ -47,7 +47,7 @@ The endpoint should also support an 'include' query parameter that returns an 'i
 ```json
 {
  "data": {
-    "type": "test_panels",
+    "type": "test_panel",
     "id": "TP2",
     "attributes": {
       "price": 2100,


### PR DESCRIPTION
## What?
- Use "test_panel" rather than "test_panels" as the type value in the sample response.

## Why?
- In the postman collection used to mark the submission we expect "test_panel".
- The spec is flexible allows for "type" to be either singular or plural, however it should be consistent with the other type values. As we're already using singular for the "test" type, we can do the same for the "test_panel" type.